### PR TITLE
rocAL fix video flag

### DIFF
--- a/rocAL/include/pipeline/master_graph.h
+++ b/rocAL/include/pipeline/master_graph.h
@@ -351,6 +351,7 @@ inline std::shared_ptr<Cifar10LoaderNode> MasterGraph::add_node(const std::vecto
     return node;
 }
 
+#ifdef ROCAL_VIDEO
 /*
  * Explicit specialization for VideoLoaderNode
  */
@@ -389,3 +390,4 @@ inline std::shared_ptr<VideoLoaderSingleShardNode> MasterGraph::add_node(const s
 
     return node;
 }
+#endif


### PR DESCRIPTION
- This PR fixes errors while building rocAL without ffmpeg
- Add ROCAL_VIDEO flag for add_node of video loaders