### PR TITLE
Fix rocAL warnings wrt amdclang++ compiler

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core[api_reference]==1.12.0
+rocm-docs-core[api_reference]==1.12.1

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -132,7 +132,7 @@ requests==2.32.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api-reference]==1.12.0
+rocm-docs-core[api-reference]==1.12.1
     # via -r requirements.in
 six==1.16.0
     # via python-dateutil

--- a/rocAL/include/api/rocal_api_augmentation.h
+++ b/rocAL/include/api/rocal_api_augmentation.h
@@ -1246,15 +1246,15 @@ extern "C" RocalTensor ROCAL_API_CALL rocalTensorAddTensor(RocalContext p_contex
  * \param [in] reference_power reference power that is used to convert the signal to dB
  * \param [in] reset_interval number of samples after which the moving mean average is recalculated to avoid loss of precision
  * \param [in] window_length size of the sliding window used to calculate of the short-term power of the signal
- * \return std::pair<RocalTensor, RocalTensor>
+ * \return RocalNSROutput
  */
-extern "C" std::pair<RocalTensor, RocalTensor> ROCAL_API_CALL rocalNonSilentRegionDetection(RocalContext context,
-                                                                                   RocalTensor input,
-                                                                                   bool is_output,
-                                                                                   float cutoff_db,
-                                                                                   float reference_power,
-                                                                                   int reset_interval,
-                                                                                   int window_length);
+extern "C" RocalNSROutput ROCAL_API_CALL rocalNonSilentRegionDetection(RocalContext context,
+                                                                       RocalTensor input,
+                                                                       bool is_output,
+                                                                       float cutoff_db,
+                                                                       float reference_power,
+                                                                       int reset_interval,
+                                                                       int window_length);
 
 /*! \brief Extracts the sub-tensor from a given input tensor
  * \ingroup group_rocal_augmentations

--- a/rocAL/include/api/rocal_api_tensor.h
+++ b/rocAL/include/api/rocal_api_tensor.h
@@ -65,6 +65,7 @@ class rocalTensor {
  */
 class rocalTensorList {
    public:
+    virtual ~rocalTensorList() = default;
     virtual uint64_t size() = 0;
     virtual rocalTensor* at(size_t index) = 0;
     // isDenseTensor

--- a/rocAL/include/api/rocal_api_tensor.h
+++ b/rocAL/include/api/rocal_api_tensor.h
@@ -81,6 +81,14 @@ class rocalListOfTensorList {
     virtual rocalTensorList* at(size_t index) = 0;
 };
 
+/*! 
+ * \brief  RocalNSROutput contains the anchor and shape tensor for NonSilentRegionDetection
+ */
+struct RocalNSROutput {
+    rocalTensor* anchor;
+    rocalTensor* shape;
+};
+
 typedef rocalTensor* RocalTensor;
 typedef rocalTensorList* RocalTensorList;
 typedef rocalListOfTensorList* RocalMetaData;

--- a/rocAL/include/api/rocal_api_tensor.h
+++ b/rocAL/include/api/rocal_api_tensor.h
@@ -71,8 +71,18 @@ class rocalTensorList {
     // isDenseTensor
 };
 
+/*!
+ * \brief class representing a list of rocal tensor list
+ */
+class rocalListOfTensorList {
+   public:
+    virtual ~rocalListOfTensorList() = default;
+    virtual uint64_t size() = 0;
+    virtual rocalTensorList* at(size_t index) = 0;
+};
+
 typedef rocalTensor* RocalTensor;
 typedef rocalTensorList* RocalTensorList;
-typedef std::vector<rocalTensorList*> RocalMetaData;
+typedef rocalListOfTensorList* RocalMetaData;
 
 #endif  // MIVISIONX_ROCAL_API_TENSOR_H

--- a/rocAL/include/augmentations/geometry_augmentations/node_resize_mirror_normalize.h
+++ b/rocAL/include/augmentations/geometry_augmentations/node_resize_mirror_normalize.h
@@ -39,7 +39,7 @@ class ResizeMirrorNormalizeNode : public Node {
     void update_node() override;
 
    private:
-    vx_array _mean_vx_array, _std_dev_vx_array, _mirror_vx_array, _dst_roi_width, _dst_roi_height;
+    vx_array _mean_vx_array, _std_dev_vx_array, _dst_roi_width, _dst_roi_height;
     std::vector<float> _mean, _std_dev;
     int _interpolation_type;
     ParameterVX<int> _mirror;

--- a/rocAL/include/decoders/image/fused_crop_decoder.h
+++ b/rocAL/include/decoders/image/fused_crop_decoder.h
@@ -62,24 +62,6 @@ class FusedCropTJDecoder : public Decoder {
 
    private:
     tjhandle m_jpegDecompressor;
-    const static unsigned SCALING_FACTORS_COUNT = 16;
-    const tjscalingfactor SCALING_FACTORS[SCALING_FACTORS_COUNT] = {
-        {2, 1},
-        {15, 8},
-        {7, 4},
-        {13, 8},
-        {3, 2},
-        {11, 8},
-        {5, 4},
-        {9, 8},
-        {1, 1},
-        {7, 8},
-        {3, 4},
-        {5, 8},
-        {1, 2},
-        {3, 8},
-        {1, 4},
-        {1, 8}};
     bool _is_partial_decoder = true;
     std::vector<float> _bbox_coord;
     CropWindow _crop_window;

--- a/rocAL/include/decoders/image/hw_jpeg_decoder.h
+++ b/rocAL/include/decoders/image/hw_jpeg_decoder.h
@@ -66,7 +66,7 @@ class HWJpegDecoder : public Decoder {
                            Decoder::ColorFormat desired_decoded_color_format, DecoderConfig config, bool keep_original_size = false) override;
 
     ~HWJpegDecoder() override;
-    void initialize(int device_id = 0);
+    void initialize(int device_id = 0) override;
     bool is_partial_decoder() override { return _is_partial_decoder; }
     void set_bbox_coords(std::vector<float> bbox_coord) override { _bbox_coord = bbox_coord; }
     void set_crop_window(CropWindow &crop_window) override { _crop_window = crop_window; }

--- a/rocAL/include/decoders/image/hw_jpeg_decoder.h
+++ b/rocAL/include/decoders/image/hw_jpeg_decoder.h
@@ -74,7 +74,6 @@ class HWJpegDecoder : public Decoder {
 
    private:
     void release();
-    const char *_src_filename = NULL;
     AVHWDeviceType _hw_type = AV_HWDEVICE_TYPE_NONE;
     AVBufferRef *_hw_device_ctx = NULL;
     AVIOContext *_io_ctx = NULL;

--- a/rocAL/include/decoders/video/hardware_video_decoder.h
+++ b/rocAL/include/decoders/video/hardware_video_decoder.h
@@ -48,7 +48,6 @@ class HardWareVideoDecoder : public VideoDecoder {
     int _video_stream_idx = -1;
     AVPixelFormat _dec_pix_fmt;
     int _codec_width, _codec_height;
-    AVHWDeviceType *hwDeviceType;
     AVBufferRef *hw_device_ctx = NULL;
     int hw_decoder_init(AVCodecContext *ctx, const enum AVHWDeviceType type, AVBufferRef *hw_device_ctx);
 };

--- a/rocAL/include/loaders/audio/audio_loader.h
+++ b/rocAL/include/loaders/audio/audio_loader.h
@@ -67,7 +67,6 @@ class AudioLoader : public LoaderModule {
     std::shared_ptr<AudioReadAndDecode> _audio_loader;
     Tensor* _output_tensor;
     std::vector<std::string> _output_names; // audio file name/ids that are stored in the _output_audio
-    MetaDataBatch* _meta_data = nullptr;    // The output of the meta_data_graph
     bool _internal_thread_running;
     size_t _output_mem_size, _batch_size, _max_decoded_samples, _max_decoded_channels;
     std::thread _load_thread;

--- a/rocAL/include/loaders/image/image_loader.h
+++ b/rocAL/include/loaders/image/image_loader.h
@@ -69,7 +69,6 @@ class ImageLoader : public LoaderModule {
     Tensor* _output_tensor;
     std::vector<std::string> _output_names;  //!< image name/ids that are stores in the _output_image
     size_t _output_mem_size;
-    MetaDataBatch* _meta_data = nullptr;  //!< The output of the meta_data_graph,
     std::vector<std::vector<float>> _bbox_coords;
     bool _internal_thread_running;
     size_t _batch_size;
@@ -90,6 +89,4 @@ class ImageLoader : public LoaderModule {
     size_t _max_tensor_width, _max_tensor_height;
     bool _external_source_reader = false;  //!< Set to true if external source reader
     bool _external_input_eos = false;      //!< Set to true for last batch for the sequence
-    RocalBatchPolicy _last_batch_policy;   //!< Last batch policy used for the reader
-    bool _last_batch_padded;                //!< Used to decide whether to pad or wrap the last batch
 };

--- a/rocAL/include/loaders/image/image_read_and_decode.h
+++ b/rocAL/include/loaders/image/image_read_and_decode.h
@@ -85,9 +85,8 @@ class ImageReadAndDecode {
     std::vector<size_t> _original_height;
     static const size_t MAX_COMPRESSED_SIZE = 1 * 1024 * 1024;  // 1 Meg
     TimingDbg _file_load_time, _decode_time;
-    size_t _batch_size, _shard_count, _num_threads;
+    size_t _batch_size, _num_threads;
     DecoderConfig _decoder_config;
-    bool decoder_keep_original;
     std::vector<std::vector<float>> _bbox_coords, _crop_coords_batch;
     std::shared_ptr<RandomBBoxCrop_MetaDataReader> _randombboxcrop_meta_data_reader = nullptr;
     pCropCord _CropCord;

--- a/rocAL/include/loaders/image/node_fused_jpeg_crop.h
+++ b/rocAL/include/loaders/image/node_fused_jpeg_crop.h
@@ -53,5 +53,4 @@ class FusedJpegCropNode : public Node {
    private:
     std::shared_ptr<ImageLoaderSharded> _loader_module = nullptr;
     std::vector<float> _random_area, _random_aspect_ratio;
-    unsigned _num_attempts;
 };

--- a/rocAL/include/loaders/image/node_fused_jpeg_crop_single_shard.h
+++ b/rocAL/include/loaders/image/node_fused_jpeg_crop_single_shard.h
@@ -50,5 +50,4 @@ class FusedJpegCropSingleShardNode : public Node {
    private:
     std::shared_ptr<ImageLoader> _loader_module = nullptr;
     std::vector<float> _random_area, _random_aspect_ratio;
-    unsigned _num_attempts;
 };

--- a/rocAL/include/meta_data/coco_meta_data_reader.h
+++ b/rocAL/include/meta_data/coco_meta_data_reader.h
@@ -46,7 +46,6 @@ class COCOMetaDataReader : public MetaDataReader {
    private:
     pMetaDataBatch _output;
     std::string _path;
-    int meta_data_reader_type;
     bool _avoid_class_remapping;
     void add(std::string image_name, BoundingBoxCords bbox, Labels labels, ImgSize image_size, int image_id = 0);
     void add(std::string image_name, BoundingBoxCords bbox, Labels labels, ImgSize image_size, MaskCords mask_cords, std::vector<int> polygon_count, std::vector<std::vector<int>> vertices_count, int image_id = 0);  // To add Mask coordinates to Metadata struct

--- a/rocAL/include/meta_data/coco_meta_data_reader_key_points.h
+++ b/rocAL/include/meta_data/coco_meta_data_reader_key_points.h
@@ -46,7 +46,6 @@ class COCOMetaDataReaderKeyPoints : public MetaDataReader {
     std::string _path;
     unsigned _out_img_width;
     unsigned _out_img_height;
-    int meta_data_reader_type;
     void add(std::string image_name, ImgSize image_size, JointsData* joints_data);
     bool exists(const std::string& image_name) override;
     std::map<std::string, std::shared_ptr<MetaData>> _map_content;

--- a/rocAL/include/meta_data/meta_data.h
+++ b/rocAL/include/meta_data/meta_data.h
@@ -109,6 +109,7 @@ typedef class MetaDataInfo {
 
 class MetaData {
    public:
+    virtual ~MetaData() = default;
     virtual std::vector<int>& get_labels() = 0;
     virtual void set_labels(Labels label_ids) = 0;
     virtual BoundingBoxCords& get_bb_cords() = 0;
@@ -139,6 +140,7 @@ class Label : public MetaData {
    public:
     Label(int label) { _label_ids = {label}; }
     Label() { _label_ids = {-1}; }
+    ~Label() = default;
     std::vector<int>& get_labels() override { return _label_ids; }
     void set_labels(Labels label_ids) override { _label_ids = std::move(label_ids); }
     BoundingBoxCords& get_bb_cords() override { THROW("Not Implemented") }
@@ -155,6 +157,7 @@ class Label : public MetaData {
 class BoundingBox : public Label {
    public:
     BoundingBox() = default;
+    ~BoundingBox() = default;
     BoundingBox(BoundingBoxCords bb_cords, Labels bb_label_ids, ImgSize img_size = ImgSize{0, 0}, int img_id = 0) {
         _bb_cords = std::move(bb_cords);
         _label_ids = std::move(bb_label_ids);
@@ -179,6 +182,7 @@ struct PolygonMask : public BoundingBox {
         _vertices_count = std::move(vertices_count);
         _info.img_id = img_id;
     }
+    ~PolygonMask() = default;
     std::vector<int>& get_polygon_count() override { return _polygon_count; }
     std::vector<std::vector<int>>& get_vertices_count() override { return _vertices_count; }
     MaskCords& get_mask_cords() override { return _mask_cords; }
@@ -195,6 +199,7 @@ struct PolygonMask : public BoundingBox {
 class KeyPoint : public BoundingBox {
    public:
     KeyPoint() = default;
+    ~KeyPoint() = default;
     KeyPoint(ImgSize img_size, JointsData* joints_data) {
         _info.img_size = std::move(img_size);
         _joints_data = std::move(*joints_data);

--- a/rocAL/include/meta_data/meta_node_crop.h
+++ b/rocAL/include/meta_data/meta_node_crop.h
@@ -40,5 +40,4 @@ class CropMetaNode : public MetaNode {
     std::shared_ptr<RocalCropParam> _meta_crop_param;
     vx_array _crop_width, _crop_height, _x1, _y1;
     std::vector<uint> _crop_width_val, _crop_height_val, _x1_val, _y1_val, _input_width_val, _input_height_val;
-    unsigned int _dst_width, _dst_height;
 };

--- a/rocAL/include/meta_data/meta_node_crop_mirror_normalize.h
+++ b/rocAL/include/meta_data/meta_node_crop_mirror_normalize.h
@@ -38,6 +38,6 @@ class CropMirrorNormalizeMetaNode : public MetaNode {
    private:
     void initialize();
     std::shared_ptr<RocalCropParam> _meta_crop_param;
-    vx_array _dst_img_width, _dst_img_height, _x1, _y1, _mirror, _src_width, _src_height;
+    vx_array _dst_img_width, _dst_img_height, _x1, _y1, _mirror;
     std::vector<uint> _width_val, _height_val, _x1_val, _y1_val, _mirror_val, _src_width_val, _src_height_val;
 };

--- a/rocAL/include/meta_data/meta_node_flip.h
+++ b/rocAL/include/meta_data/meta_node_flip.h
@@ -39,6 +39,5 @@ class FlipMetaNode : public MetaNode {
 
    private:
     void initialize();
-    vx_array _src_width, _src_height;
     std::vector<int> _h_flip_val, _v_flip_val;
 };

--- a/rocAL/include/meta_data/meta_node_rotate.h
+++ b/rocAL/include/meta_data/meta_node_rotate.h
@@ -41,7 +41,6 @@ class RotateMetaNode : public MetaNode {
 
    private:
     void initialize();
-    vx_array _src_width, _src_height;
     std::vector<uint> _src_width_val, _src_height_val;
     unsigned int _dst_width, _dst_height;
     vx_array _angle;

--- a/rocAL/include/meta_data/meta_node_ssd_random_crop.h
+++ b/rocAL/include/meta_data/meta_node_ssd_random_crop.h
@@ -48,6 +48,5 @@ class SSDRandomCropMetaNode : public MetaNode {
     unsigned int _dst_width, _dst_height;
     float _threshold = 0.5;
     int _num_of_attempts = 20;
-    bool _enitire_iou = true;  // For entire_iou - true and For relative iou - false
     void initialize();
 };

--- a/rocAL/include/parameters/parameter_crop.h
+++ b/rocAL/include/parameters/parameter_crop.h
@@ -44,6 +44,7 @@ class CropParam {
     // V Y directoin
    public:
     CropParam() = delete;
+    virtual ~CropParam() = default;
     CropParam(unsigned int batch_size) : batch_size(batch_size), _random(false), _is_fixed_crop(false) {
         x_drift_factor = default_x_drift_factor();
         y_drift_factor = default_y_drift_factor();

--- a/rocAL/include/parameters/parameter_random_crop.h
+++ b/rocAL/include/parameters/parameter_random_crop.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 class RocalRandomCropParam : public CropParam {
    public:
     RocalRandomCropParam() = delete;
+    ~RocalRandomCropParam() = default;
     RocalRandomCropParam(unsigned int batch_size) : CropParam(batch_size) {
         area_factor = default_area_factor();
         aspect_ratio = default_aspect_ratio();

--- a/rocAL/include/parameters/parameter_random_crop_decoder.h
+++ b/rocAL/include/parameters/parameter_random_crop_decoder.h
@@ -62,7 +62,6 @@ class RocalRandomCropDecParam {
     std::uniform_real_distribution<float> _area_dis;
     // thread_local is needed to call it from multiple threads async, so each thread will have its own copy
     static thread_local std::mt19937 _rand_gen;
-    int64_t _seed;
     std::vector<int> _seeds;
     int _num_attempts;
     int _batch_size;

--- a/rocAL/include/parameters/parameter_rocal_crop.h
+++ b/rocAL/include/parameters/parameter_rocal_crop.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 class RocalCropParam : public CropParam {
    public:
     RocalCropParam() = delete;
+    ~RocalCropParam() = default;
     RocalCropParam(unsigned int batch_size) : CropParam(batch_size) {
         crop_height_factor = default_crop_height_factor();
         crop_width_factor = default_crop_width_factor();

--- a/rocAL/include/pipeline/graph.h
+++ b/rocAL/include/pipeline/graph.h
@@ -36,7 +36,6 @@ class Graph {
     vx_graph get() { return _graph; }
 
    private:
-    RocalMemType _mem_type;
     vx_context _context = nullptr;
     vx_graph _graph = nullptr;
     RocalAffinity _affinity;

--- a/rocAL/include/pipeline/master_graph.h
+++ b/rocAL/include/pipeline/master_graph.h
@@ -203,7 +203,6 @@ class MasterGraph {
     bool _loop;                                                                   //!< Indicates if user wants to indefinitely loops through tensors or not
     size_t _prefetch_queue_depth;
     bool _output_routine_finished_processing = false;
-    const RocalTensorDataType _out_data_type;
     bool _is_random_bbox_crop = false;
     std::vector<std::vector<size_t>> _sequence_start_framenum_vec;                //!< Stores the starting frame number of the sequences.
     std::vector<std::vector<std::vector<float>>> _sequence_frame_timestamps_vec;  //!< Stores the timestamps of the frames in a sequences.

--- a/rocAL/include/pipeline/master_graph.h
+++ b/rocAL/include/pipeline/master_graph.h
@@ -111,15 +111,15 @@ class MasterGraph {
     std::shared_ptr<T> meta_add_node(std::shared_ptr<M> node);
     Tensor *create_tensor(const TensorInfo &info, bool is_output);
     Tensor *create_loader_output_tensor(const TensorInfo &info);
-    std::vector<rocalTensorList *> create_label_reader(const char *source_path, MetaDataReaderType reader_type);
-    std::vector<rocalTensorList *> create_video_label_reader(const char *source_path, MetaDataReaderType reader_type, unsigned sequence_length, unsigned frame_step, unsigned frame_stride, bool file_list_frame_num = true);
-    std::vector<rocalTensorList *> create_coco_meta_data_reader(const char *source_path, bool is_output, MetaDataReaderType reader_type, MetaDataType label_type, bool ltrb_bbox = true, bool is_box_encoder = false,
+    TensorListVector * create_label_reader(const char *source_path, MetaDataReaderType reader_type);
+    TensorListVector * create_video_label_reader(const char *source_path, MetaDataReaderType reader_type, unsigned sequence_length, unsigned frame_step, unsigned frame_stride, bool file_list_frame_num = true);
+    TensorListVector * create_coco_meta_data_reader(const char *source_path, bool is_output, MetaDataReaderType reader_type, MetaDataType label_type, bool ltrb_bbox = true, bool is_box_encoder = false,
                                                                 bool avoid_class_remapping = false, bool aspect_ratio_grouping = false, bool is_box_iou_matcher = false, float sigma = 0.0, unsigned pose_output_width = 0, unsigned pose_output_height = 0);
-    std::vector<rocalTensorList *> create_tf_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type, const std::map<std::string, std::string> feature_key_map);
-    std::vector<rocalTensorList *> create_caffe_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type);
-    std::vector<rocalTensorList *> create_caffe2_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type);
-    std::vector<rocalTensorList *> create_cifar10_label_reader(const char *source_path, const char *file_prefix);
-    std::vector<rocalTensorList *> create_mxnet_label_reader(const char *source_path, bool is_output);
+    TensorListVector * create_tf_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type, const std::map<std::string, std::string> feature_key_map);
+    TensorListVector * create_caffe_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type);
+    TensorListVector * create_caffe2_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type);
+    TensorListVector * create_cifar10_label_reader(const char *source_path, const char *file_prefix);
+    TensorListVector * create_mxnet_label_reader(const char *source_path, bool is_output);
     void box_encoder(std::vector<float> &anchors, float criteria, const std::vector<float> &means, const std::vector<float> &stds, bool offset, float scale);
     void box_iou_matcher(std::vector<float> &anchors, float high_threshold, float low_threshold, bool allow_low_quality_matches);
     void create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType reader_type, RandomBBoxCrop_MetaDataType label_type, bool all_boxes_overlap, bool no_crop, FloatParam *aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, FloatParam *scaling, int total_num_attempts, int64_t seed = 0);
@@ -139,7 +139,7 @@ class MasterGraph {
     bool is_sequence_reader_output() { return _is_sequence_reader_output; }
     void set_sequence_reader_output() { _is_sequence_reader_output = true; }
     void set_sequence_batch_size(size_t sequence_length) { _sequence_batch_size = _user_batch_size * sequence_length; }
-    std::vector<rocalTensorList *> get_bbox_encoded_buffers(size_t num_encoded_boxes);
+    TensorListVector * get_bbox_encoded_buffers(size_t num_encoded_boxes);
     void feed_external_input(const std::vector<std::string>& input_images_names, bool labels, const std::vector<unsigned char *>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode,
                              RocalTensorlayout layout, bool eos);
@@ -171,9 +171,8 @@ class MasterGraph {
     std::list<std::shared_ptr<Node>> _meta_data_nodes;                            //!< List of nodes where meta data has to be updated after augmentation
     std::map<Tensor *, std::shared_ptr<Node>> _tensor_map;                        //!< key: tensor, value : Parent node
     void *_output_tensor_buffer = nullptr;                                        //!< In the GPU processing case , is used to convert the U8 samples to float32 before they are being transfered back to host
-
-    // Output tensorList for metadata
-    std::vector<rocalTensorList *> _metadata_output_tensor_list;
+    TensorListVector _metadata_output_tensor_list;                                //!< Keeps a list of all the Metadata output TensorList
+    TensorListVector _bbox_encoded_output;                                        //!< Keeps a list of label and bounding box metadata TensorList for box encoder
     TensorList _labels_tensor_list;
     TensorList _bbox_tensor_list;
     TensorList _mask_tensor_list;

--- a/rocAL/include/pipeline/ring_buffer.h
+++ b/rocAL/include/pipeline/ring_buffer.h
@@ -77,7 +77,6 @@ class RingBuffer {
     bool full();
     const unsigned BUFF_DEPTH;
     std::vector<size_t> _sub_buffer_size;
-    unsigned _sub_buffer_count;
     std::vector<std::vector<size_t>> _meta_data_sub_buffer_size;
     unsigned _meta_data_sub_buffer_count;
     std::mutex _lock;

--- a/rocAL/include/pipeline/tensor.h
+++ b/rocAL/include/pipeline/tensor.h
@@ -308,7 +308,7 @@ class Tensor : public rocalTensor {
     const TensorInfo& info() { return _info; }
     //! Default constructor
     Tensor() = delete;
-    void* buffer() { return _mem_handle; }
+    void* buffer() override { return _mem_handle; }
     vx_tensor handle() { return _vx_handle; }
     vx_context context() { return _context; }
     void set_mem_handle(void* buffer) override {
@@ -326,7 +326,7 @@ class Tensor : public rocalTensor {
 #endif
     unsigned copy_data(void* user_buffer, RocalOutputMemType external_mem_type) override;
     //! Copying the output buffer with specified max_cols and max_rows values for the 2D buffer of size batch_size
-    unsigned copy_data(void* user_buffer, uint x_offset, uint y_offset, uint max_rows, uint max_cols); 
+    unsigned copy_data(void* user_buffer, uint x_offset, uint y_offset, uint max_rows, uint max_cols) override;
     //! Default destructor
     /*! Releases the OpenVX Tensor object */
     ~Tensor();

--- a/rocAL/include/pipeline/tensor.h
+++ b/rocAL/include/pipeline/tensor.h
@@ -407,3 +407,24 @@ class TensorList : public rocalTensorList {
     std::vector<uint64_t> _tensor_data_size;
     std::vector<uint64_t> _tensor_roi_size;
 };
+
+/*! \brief Contains a list of rocalTensorList */
+class TensorListVector : public rocalListOfTensorList {
+   public:
+    uint64_t size() override { return _tensor_list_vector.size(); }
+    bool empty() { return _tensor_list_vector.empty(); }
+    TensorList* front() { return _tensor_list_vector.front(); }
+    void push_back(TensorList* tensor_list) {
+        _tensor_list_vector.push_back(tensor_list);
+    }
+    void emplace_back(TensorList* tensor_list) {
+        _tensor_list_vector.emplace_back(tensor_list);
+    }
+    void release() {
+        for (auto& tensor_list : _tensor_list_vector) tensor_list->release();
+    }
+    TensorList* operator[](size_t index) { return _tensor_list_vector[index]; }
+    TensorList* at(size_t index) override { return _tensor_list_vector[index]; }
+   private:
+    std::vector<TensorList*> _tensor_list_vector;
+};

--- a/rocAL/include/readers/file_source_reader.h
+++ b/rocAL/include/readers/file_source_reader.h
@@ -93,6 +93,5 @@ class FileSourceReader : public Reader {
     int release();
     std::shared_ptr<MetaDataReader> _meta_data_reader = nullptr;
     //! Pair containing the last batch policy and pad_last_batch_repeated values for deciding what to do with last batch
-    size_t _num_padded_samples = 0;                  //! Number of samples that are padded in the last batch which would differ for each shard.
     Reader::Status generate_file_names();         // Function that would generate _file_names containing all the samples in the dataset
 };

--- a/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
+++ b/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
@@ -85,7 +85,6 @@ class Caffe2LMDBRecordReader : public Reader {
     unsigned int _last_file_size;
     bool _last_rec;
     size_t _batch_size = 1;
-    size_t _in_batch_read_count = 0;
     bool _loop;
     bool _shuffle;
     int _read_counter = 0;
@@ -97,7 +96,6 @@ class Caffe2LMDBRecordReader : public Reader {
     void read_image_names();
     std::map<std::string, uint> _image_record_starting;
     int _open_env = 1;
-    int rc;
     MDB_env* _read_mdb_env;
     MDB_dbi _read_mdb_dbi;
     MDB_val _read_mdb_key, _read_mdb_value;

--- a/rocAL/include/readers/image/caffe_lmdb_record_reader.h
+++ b/rocAL/include/readers/image/caffe_lmdb_record_reader.h
@@ -83,8 +83,6 @@ class CaffeLMDBRecordReader : public Reader {
     unsigned int _last_file_size;
     bool _last_rec;
     size_t _batch_size = 1;
-    size_t _file_id = 0;
-    size_t _in_batch_read_count = 0;
     bool _loop;
     bool _shuffle;
     int _read_counter = 0;
@@ -100,7 +98,6 @@ class CaffeLMDBRecordReader : public Reader {
     void read_image_names();
     std::map<std::string, uint> _image_record_starting;
     int _open_env = 1;
-    int rc;
     void open_env_for_read_image();
     std::shared_ptr<MetaDataReader> _meta_data_reader = nullptr;
 };

--- a/rocAL/include/readers/image/mxnet_recordio_reader.h
+++ b/rocAL/include/readers/image/mxnet_recordio_reader.h
@@ -82,8 +82,6 @@ class MXNetRecordIOReader : public Reader {
     int64_t _last_seek_pos;
     int64_t _last_data_size;
     size_t _batch_size = 1;
-    size_t _file_id = 0;
-    size_t _in_batch_read_count = 0;
     bool _loop;
     bool _shuffle;
     int _read_counter = 0;

--- a/rocAL/source/api/rocal_api_augmentation.cpp
+++ b/rocAL/source/api/rocal_api_augmentation.cpp
@@ -2235,7 +2235,7 @@ rocalSpectrogram(
                                             context->master_graph->mem_type(),
                                             op_tensor_data_type,
                                             spectrogram_layout);
-        if(power != 1 || power != 2) {
+        if(power != 1 && power != 2) {
             WRN("rocalSpectrogram power value can be 1 or 2, setting it to default 2")
             power = 2;
         }

--- a/rocAL/source/api/rocal_api_augmentation.cpp
+++ b/rocAL/source/api/rocal_api_augmentation.cpp
@@ -2438,7 +2438,7 @@ RocalTensor rocalNormalDistribution(RocalContext p_context,
     return output;
 }
 
-std::pair<RocalTensor, RocalTensor> ROCAL_API_CALL
+RocalNSROutput ROCAL_API_CALL
 rocalNonSilentRegionDetection(
     RocalContext p_context,
     RocalTensor p_input,
@@ -2449,6 +2449,7 @@ rocalNonSilentRegionDetection(
     int window_length) {
     Tensor* anchor_output = nullptr;
     Tensor* shape_output = nullptr;
+    RocalNSROutput output;
     if ((p_context == nullptr) || (p_input == nullptr))
         ERR("Invalid ROCAL context or invalid input tensor")
     auto context = static_cast<Context*>(p_context);
@@ -2467,12 +2468,14 @@ rocalNonSilentRegionDetection(
         anchor_output = context->master_graph->create_tensor(info1, is_output);
         shape_output = context->master_graph->create_tensor(info2, is_output);
         context->master_graph->add_node<NonSilentRegionDetectionNode>({input}, {anchor_output, shape_output})->init(cutoff_db, reference_power, window_length, reset_interval);
+        output.anchor = anchor_output;
+        output.shape = shape_output;
     } catch (const std::exception& e) {
         context->capture_error(e.what());
         ERR(e.what())
     }
 
-    return std::make_pair(anchor_output, shape_output);
+    return output;
 }
 
 RocalTensor ROCAL_API_CALL

--- a/rocAL/source/augmentations/effects_augmentations/node_normalize.cpp
+++ b/rocAL/source/augmentations/effects_augmentations/node_normalize.cpp
@@ -42,7 +42,7 @@ void NormalizeNode::create_node() {
 
     int mean_stddev_array_size = 1;
     auto nDim = _inputs[0]->info().num_of_dims() - 1;
-    uint axis[nDim];
+    std::vector<unsigned> axis(nDim);
     for (unsigned i = 0; i < _batch_size; i++) {
         int totalElements = 1;
         unsigned *tensor_shape = _inputs[0]->info().roi()[i].end;

--- a/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
+++ b/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
@@ -99,7 +99,7 @@ void CropNode::init(FloatParam *crop_h_factor, FloatParam *crop_w_factor, FloatP
 
 // Create vx_tensor for the crop coordinates
 void CropNode::create_crop_tensor() {
-    vx_size num_of_dims = 2;
+    const vx_size num_of_dims = 2;
     vx_size stride[num_of_dims];
     std::vector<size_t> _crop_tensor_dims = {_batch_size, 4};
     if(_inputs[0]->info().layout() == RocalTensorlayout::NFCHW || _inputs[0]->info().layout() == RocalTensorlayout::NFHWC)

--- a/rocAL/source/decoders/image/hw_jpeg_decoder.cpp
+++ b/rocAL/source/decoders/image/hw_jpeg_decoder.cpp
@@ -244,7 +244,6 @@ Decoder::Status HWJpegDecoder::decode(unsigned char *input_buffer, size_t input_
         return Status::NO_MEMORY;
     }
 
-    unsigned frame_count = 0;
     bool end_of_stream = false;
     AVPacket pkt;
     uint8_t *dst_data[4] = {0};
@@ -300,7 +299,6 @@ Decoder::Status HWJpegDecoder::decode(unsigned char *input_buffer, size_t input_
             }
             av_packet_unref(&pkt);
             output_buffer += image_size;
-            frame_count++;
         }
     } while (!end_of_stream);
 

--- a/rocAL/source/meta_data/randombboxcrop_reader.cpp
+++ b/rocAL/source/meta_data/randombboxcrop_reader.cpp
@@ -125,7 +125,6 @@ void RandomBBoxCropReader::read_all() {
     release();
     const std::vector<float> sample_options = {-1.0f, 0.1f, 0.3f, 0.5f, 0.7f, 0.9f, 0.0f};
     int sample_option;
-    std::pair<bool, float> option;
     float min_iou;
     bool invalid_bboxes;
     bool crop_success;
@@ -225,7 +224,6 @@ RandomBBoxCropReader::get_batch_crop_coords(const std::vector<std::string> &imag
     }
     const std::vector<float> sample_options = {-1.0f, 0.1f, 0.3f, 0.5f, 0.7f, 0.9f, 0.0f};
     std::vector<float> coords_buf(4);
-    std::pair<bool, float> option;
     bool invalid_bboxes;
     bool crop_success;
     BoundingBoxCord crop_box;

--- a/rocAL/source/parameters/parameter_random_crop_decoder.cpp
+++ b/rocAL/source/parameters/parameter_random_crop_decoder.cpp
@@ -33,7 +33,7 @@ RocalRandomCropDecParam::RocalRandomCropDecParam(
     int64_t seed,
     int num_attempts,
     int batch_size)
-    : _aspect_ratio_range(aspect_ratio_range), _aspect_ratio_log_dis(std::log(aspect_ratio_range.first), std::log(aspect_ratio_range.second)), _area_dis(area_range.first, area_range.second), _seed(seed), _num_attempts(num_attempts), _batch_size(batch_size) {
+    : _aspect_ratio_range(aspect_ratio_range), _aspect_ratio_log_dis(std::log(aspect_ratio_range.first), std::log(aspect_ratio_range.second)), _area_dis(area_range.first, area_range.second), _num_attempts(num_attempts), _batch_size(batch_size) {
     _seeds.resize(_batch_size);
 }
 

--- a/rocAL/source/pipeline/graph.cpp
+++ b/rocAL/source/pipeline/graph.cpp
@@ -47,15 +47,14 @@ get_ago_affinity_info(
     return affinity;
 }
 
-Graph::Graph(vx_context context, RocalAffinity affinity, int cpu_id, size_t cpu_num_threads, int gpu_id) : _mem_type(((affinity == RocalAffinity::GPU) ? RocalMemType::HIP : RocalMemType::HOST)),
-                                                                                                           _context(context),
+Graph::Graph(vx_context context, RocalAffinity affinity, int cpu_id, size_t cpu_num_threads, int gpu_id) : _context(context),
                                                                                                            _graph(nullptr),
                                                                                                            _affinity(affinity),
                                                                                                            _gpu_id(gpu_id),
                                                                                                            _cpu_id(cpu_id) {
     try {
         vx_status status;
-        auto vx_affinity = get_ago_affinity_info(_affinity, cpu_id, gpu_id);
+        auto vx_affinity = get_ago_affinity_info(_affinity, _cpu_id, _gpu_id);
         vx_uint32 _cpu_num_threads = cpu_num_threads;
 
         _graph = vxCreateGraph(_context);

--- a/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/source/pipeline/master_graph.cpp
@@ -112,7 +112,6 @@ MasterGraph::MasterGraph(size_t batch_size, RocalAffinity affinity, size_t cpu_t
                                                                                                                                                                                      _first_run(true),
                                                                                                                                                                                      _processing(false),
                                                                                                                                                                                      _prefetch_queue_depth(prefetch_queue_depth),
-                                                                                                                                                                                     _out_data_type(output_tensor_data_type),
 #if ENABLE_HIP
                                                                                                                                                                                      _box_encoder_gpu(nullptr),
 #endif

--- a/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/source/pipeline/master_graph.cpp
@@ -344,8 +344,8 @@ void MasterGraph::release() {
         delete tensor;                // It will call the vxReleaseTensor internally in the destructor
     _internal_tensor_list.release();  // It will call the vxReleaseTensor internally in the destructor for each tensor in the list
     _output_tensor_list.release();    // It will call the vxReleaseTensor internally in the destructor for each tensor in the list
-    for (auto tensor_list : _metadata_output_tensor_list)
-        dynamic_cast<TensorList *>(tensor_list)->release();  // It will call the vxReleaseTensor internally in the destructor for each tensor in the list
+    _metadata_output_tensor_list.release(); // It will call the vxReleaseTensor internally in the destructor for each tensor in the list of TensorList
+    _bbox_encoded_output.release(); // It will call the vxReleaseTensor internally in the destructor for each tensor in the list of TensorList
 
     if (_graph != nullptr)
         _graph->release();
@@ -1012,7 +1012,7 @@ void MasterGraph::stop_processing() {
         _output_thread.join();
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_coco_meta_data_reader(const char *source_path, bool is_output, MetaDataReaderType reader_type, MetaDataType metadata_type, bool ltrb_bbox, bool is_box_encoder, bool avoid_class_remapping, bool aspect_ratio_grouping, bool is_box_iou_matcher, float sigma, unsigned pose_output_width, unsigned pose_output_height) {
+TensorListVector* MasterGraph::create_coco_meta_data_reader(const char *source_path, bool is_output, MetaDataReaderType reader_type, MetaDataType metadata_type, bool ltrb_bbox, bool is_box_encoder, bool avoid_class_remapping, bool aspect_ratio_grouping, bool is_box_iou_matcher, float sigma, unsigned pose_output_width, unsigned pose_output_height) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1078,10 +1078,10 @@ std::vector<rocalTensorList *> MasterGraph::create_coco_meta_data_reader(const c
     if(is_box_iou_matcher)
         _metadata_output_tensor_list.emplace_back(&_matches_tensor_list);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_tf_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type, std::map<std::string, std::string> feature_key_map) {
+TensorListVector* MasterGraph::create_tf_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type, std::map<std::string, std::string> feature_key_map) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1127,10 +1127,10 @@ std::vector<rocalTensorList *> MasterGraph::create_tf_record_meta_data_reader(co
 
     _ring_buffer.init_metadata(RocalMemType::HOST, _meta_data_buffer_size);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_label_reader(const char *source_path, MetaDataReaderType reader_type) {
+TensorListVector* MasterGraph::create_label_reader(const char *source_path, MetaDataReaderType reader_type) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1153,10 +1153,10 @@ std::vector<rocalTensorList *> MasterGraph::create_label_reader(const char *sour
     _ring_buffer.init_metadata(RocalMemType::HOST, _meta_data_buffer_size);
     _metadata_output_tensor_list.emplace_back(&_labels_tensor_list);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_video_label_reader(const char *source_path, MetaDataReaderType reader_type, unsigned sequence_length, unsigned frame_step, unsigned frame_stride, bool file_list_frame_num) {
+TensorListVector* MasterGraph::create_video_label_reader(const char *source_path, MetaDataReaderType reader_type, unsigned sequence_length, unsigned frame_step, unsigned frame_stride, bool file_list_frame_num) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1183,10 +1183,10 @@ std::vector<rocalTensorList *> MasterGraph::create_video_label_reader(const char
     _meta_data_reader->read_all(source_path);
     _metadata_output_tensor_list.emplace_back(&_labels_tensor_list);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_mxnet_label_reader(const char *source_path, bool is_output) {
+TensorListVector* MasterGraph::create_mxnet_label_reader(const char *source_path, bool is_output) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1209,7 +1209,7 @@ std::vector<rocalTensorList *> MasterGraph::create_mxnet_label_reader(const char
     _metadata_output_tensor_list.emplace_back(&_labels_tensor_list);
     _ring_buffer.init_metadata(RocalMemType::HOST, _meta_data_buffer_size);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
 void MasterGraph::create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType reader_type, RandomBBoxCrop_MetaDataType label_type, bool all_boxes_overlap, bool no_crop, FloatParam *aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, FloatParam *scaling, int total_num_attempts, int64_t seed) {
@@ -1242,7 +1242,7 @@ void MasterGraph::box_encoder(std::vector<float> &anchors, float criteria, const
     _stds = stds;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_caffe2_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type) {
+TensorListVector* MasterGraph::create_caffe2_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1287,10 +1287,10 @@ std::vector<rocalTensorList *> MasterGraph::create_caffe2_lmdb_record_meta_data_
 
     _ring_buffer.init_metadata(RocalMemType::HOST, _meta_data_buffer_size);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_caffe_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type) {
+TensorListVector* MasterGraph::create_caffe_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type, MetaDataType label_type) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1335,10 +1335,10 @@ std::vector<rocalTensorList *> MasterGraph::create_caffe_lmdb_record_meta_data_r
 
     _ring_buffer.init_metadata(RocalMemType::HOST, _meta_data_buffer_size);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
-std::vector<rocalTensorList *> MasterGraph::create_cifar10_label_reader(const char *source_path, const char *file_prefix) {
+TensorListVector* MasterGraph::create_cifar10_label_reader(const char *source_path, const char *file_prefix) {
     if (_meta_data_reader)
         THROW("A metadata reader has already been created")
     if (_augmented_meta_data)
@@ -1360,7 +1360,7 @@ std::vector<rocalTensorList *> MasterGraph::create_cifar10_label_reader(const ch
     _metadata_output_tensor_list.emplace_back(&_labels_tensor_list);
     _ring_buffer.init_metadata(RocalMemType::HOST, _meta_data_buffer_size);
 
-    return _metadata_output_tensor_list;
+    return &_metadata_output_tensor_list;
 }
 
 const std::pair<ImageNameBatch, pMetaDataBatch> &MasterGraph::meta_data() {
@@ -1602,9 +1602,8 @@ MasterGraph::copy_out_tensor_planar(void *out_ptr, RocalTensorlayout format, flo
     return Status::OK;
 }
 
-std::vector<rocalTensorList *>
+TensorListVector*
 MasterGraph::get_bbox_encoded_buffers(size_t num_encoded_boxes) {
-    std::vector<rocalTensorList *> bbox_encoded_output;
     if (_is_box_encoder) {
         if (num_encoded_boxes != _user_batch_size * _num_anchors) {
             THROW("num_encoded_boxes is not correct");
@@ -1624,10 +1623,10 @@ MasterGraph::get_bbox_encoded_buffers(size_t num_encoded_boxes) {
             labels_buf_ptr += _labels_tensor_list[i]->info().data_size();
             boxes_buf_ptr += _bbox_tensor_list[i]->info().data_size();
         }
-        bbox_encoded_output.emplace_back(&_labels_tensor_list);
-        bbox_encoded_output.emplace_back(&_bbox_tensor_list);
+        _bbox_encoded_output.emplace_back(&_labels_tensor_list);
+        _bbox_encoded_output.emplace_back(&_bbox_tensor_list);
     }
-    return bbox_encoded_output;
+    return &_bbox_encoded_output;
 }
 
 void MasterGraph::feed_external_input(const std::vector<std::string>& input_images_names, bool is_labels, const std::vector<unsigned char *>& input_buffer,

--- a/rocAL/source/pipeline/ring_buffer.cpp
+++ b/rocAL/source/pipeline/ring_buffer.cpp
@@ -388,9 +388,9 @@ void RingBuffer::increment_write_ptr() {
 
 void RingBuffer::set_meta_data(ImageNameBatch names, pMetaDataBatch meta_data) {
     if (meta_data == nullptr)
-        _last_image_meta_data = std::move(std::make_pair(std::move(names), pMetaDataBatch()));
+        _last_image_meta_data = std::make_pair(std::move(names), pMetaDataBatch());
     else {
-        _last_image_meta_data = std::move(std::make_pair(std::move(names), meta_data));
+        _last_image_meta_data = std::make_pair(std::move(names), meta_data);
         if (!_box_encoder) {
             auto actual_buffer_size = meta_data->get_buffer_size();
             for (unsigned i = 0; i < actual_buffer_size.size(); i++) {

--- a/rocAL/source/pipeline/tensor.cpp
+++ b/rocAL/source/pipeline/tensor.cpp
@@ -313,14 +313,14 @@ int Tensor::create_from_handle(vx_context context) {
     _context = context;
     vx_enum tensor_data_type = interpret_tensor_data_type(_info.data_type());
     unsigned num_of_dims = _info.num_of_dims();
-    vx_size stride[num_of_dims];
+    std::vector<vx_size> stride(num_of_dims);
     void *ptr[1] = {nullptr};
 
     stride[0] = tensor_data_size(_info.data_type());
     for (unsigned i = 1; i < num_of_dims; i++)
         stride[i] = stride[i - 1] * _info.dims().at(i - 1);
 
-    _vx_handle = vxCreateTensorFromHandle(_context, _info.num_of_dims(), _info.dims().data(), tensor_data_type, 0, stride, ptr, vx_mem_type(_info._mem_type));
+    _vx_handle = vxCreateTensorFromHandle(_context, _info.num_of_dims(), _info.dims().data(), tensor_data_type, 0, stride.data(), ptr, vx_mem_type(_info._mem_type));
     vx_status status;
     if ((status = vxGetStatus((vx_reference)_vx_handle)) != VX_SUCCESS)
         THROW("Error: vxCreateTensorFromHandle(input: failed " + TOSTR(status))
@@ -356,7 +356,7 @@ void Tensor::create_roi_tensor_from_handle(void **handle) {
         THROW("Empty ROI handle is passed")
     }
 
-    vx_size num_of_dims = 2;
+    const vx_size num_of_dims = 2;
     vx_size stride[num_of_dims];
     std::vector<size_t> roi_dims = {_info.batch_size(), 4};
     if (_info.layout() == RocalTensorlayout::NFCHW || _info.layout() == RocalTensorlayout::NFHWC)

--- a/rocAL_pybind/amd/rocal/fn.py
+++ b/rocAL_pybind/amd/rocal/fn.py
@@ -1164,7 +1164,7 @@ def nonsilent_region(*inputs, cutoff_db = -60, reference_power = 0.0, reset_inte
     kwargs_pybind = {"input_audio": inputs[0], "is_output": False, "cutoff_db": cutoff_db,
                      "reference_power": reference_power, "reset_interval": reset_interval, "window_length": window_length}
     non_silent_region_output = b.nonSilentRegionDetection(Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
-    return non_silent_region_output
+    return non_silent_region_output.anchor, non_silent_region_output.shape
 
 def slice(*inputs, anchor = [], shape = [], fill_values = [0.0],  out_of_bounds_policy = types.ERROR, rocal_tensor_output_type = types.FLOAT):
     """

--- a/rocAL_pybind/rocal_pybind.cpp
+++ b/rocAL_pybind/rocal_pybind.cpp
@@ -741,6 +741,10 @@ PYBIND11_MODULE(rocal_pybind, m) {
         .def_readwrite("pad_last_batch_repeated", &RocalShardingInfo::pad_last_batch_repeated)
         .def_readwrite("stick_to_shard", &RocalShardingInfo::stick_to_shard)
         .def_readwrite("shard_size", &RocalShardingInfo::shard_size);
+    py::class_<RocalNSROutput>(m, "RocalNSROutput")
+        .def(py::init<>())
+        .def_readonly("anchor", &RocalNSROutput::anchor)
+        .def_readonly("shape", &RocalNSROutput::shape);
     // rocal_api_info.h
     m.def("getRemainingImages", &rocalGetRemainingImages);
     m.def("getImageName", &wrapper_image_name);

--- a/rocAL_pybind/rocal_pybind.cpp
+++ b/rocAL_pybind/rocal_pybind.cpp
@@ -903,8 +903,8 @@ PYBIND11_MODULE(rocal_pybind, m) {
         py::return_value_policy::reference);
     m.def("rocalGetEncodedBoxesAndLables", [](RocalContext context, uint batch_size, uint num_anchors) {
         auto vec_pair_labels_boxes = rocalGetEncodedBoxesAndLables(context, batch_size * num_anchors);
-        auto labels_buf_ptr = static_cast<int *>(vec_pair_labels_boxes[0]->at(0)->buffer());
-        auto bboxes_buf_ptr = static_cast<float *>(vec_pair_labels_boxes[1]->at(0)->buffer());
+        auto labels_buf_ptr = static_cast<int *>(vec_pair_labels_boxes->at(0)->at(0)->buffer());
+        auto bboxes_buf_ptr = static_cast<float *>(vec_pair_labels_boxes->at(1)->at(0)->buffer());
 
         py::array_t<int> labels_array = py::array_t<int>(py::buffer_info(
             labels_buf_ptr,

--- a/rocAL_pybind/rocal_pybind.cpp
+++ b/rocAL_pybind/rocal_pybind.cpp
@@ -632,6 +632,16 @@ PYBIND11_MODULE(rocal_pybind, m) {
                 Returns a rocal tensor at given position `i` in the rocalTensorlist.
                 )code",
             py::keep_alive<0, 1>());
+py::class_<rocalListOfTensorList>(m, "rocalListOfTensorList")
+        .def(
+            "__getitem__",
+            [](rocalListOfTensorList &output_tensor_list, uint idx) {
+                return output_tensor_list.at(idx);
+            },
+            R"code(
+                Returns a TensorList at given position in the list.
+                )code",
+            py::return_value_policy::reference);
 
     py::module types_m = m.def_submodule("types");
     types_m.doc() = "Datatypes and options used by ROCAL";

--- a/tests/cpp_api/audio_tests/audio_tests.cpp
+++ b/tests/cpp_api/audio_tests/audio_tests.cpp
@@ -254,7 +254,7 @@ int test(int test_case, const char *path, int qa_mode, int downmix, int gpu) {
             std::vector<float> fill_values = {0.0};
             std::vector<unsigned> axes = {0};
             auto nsr_output = rocalNonSilentRegionDetection(handle, decoded_output, false, -60.0, 0.0, 8192, 2048);
-            rocalSlice(handle, decoded_output, true, nsr_output.first, nsr_output.second, fill_values, ROCAL_ERROR, ROCAL_FP32);
+            rocalSlice(handle, decoded_output, true, nsr_output.anchor, nsr_output.shape, fill_values, ROCAL_ERROR, ROCAL_FP32);
         } break;
         case 10: {
             std::cout << "Running MEL FILTER BANK " << std::endl;

--- a/tests/cpp_api/basic_test/basic_test.cpp
+++ b/tests/cpp_api/basic_test/basic_test.cpp
@@ -79,7 +79,7 @@ int main(int argc, const char **argv) {
     if (argc >= argIdx + MIN_ARG_COUNT)
         decode_shard_counts = atoi(argv[++argIdx]);
 
-    int inputBatchSize = 4;
+    const int inputBatchSize = 4;
 
     std::cout << ">>> Running on " << (processing_device ? "GPU" : "CPU") << std::endl;
 
@@ -169,9 +169,9 @@ int main(int argc, const char **argv) {
             RocalTensorList labels = rocalGetImageLabels(handle);
 
             unsigned imagename_size = rocalGetImageNameLen(handle, ImageNameLen);
-            char imageNames[imagename_size];
-            rocalGetImageName(handle, imageNames);
-            std::string imageNamesStr(imageNames);
+            std::vector<char> imageNames(imagename_size);
+            rocalGetImageName(handle, imageNames.data());
+            std::string imageNamesStr(imageNames.data());
 
             int pos = 0;
             int *labels_buffer = reinterpret_cast<int *>(labels->at(0)->buffer());

--- a/tests/cpp_api/dataloader_multithread/dataloader_multithread.cpp
+++ b/tests/cpp_api/dataloader_multithread/dataloader_multithread.cpp
@@ -129,7 +129,7 @@ int thread_func(const char *path, int gpu_mode, RocalImageColor color_format, in
     int counter = 0;
     std::vector<std::string> names;
     names.resize(batch_size);
-    int image_name_length[batch_size];
+    std::vector<int> image_name_length(batch_size);
     if (DISPLAY)
         cv::namedWindow("output", CV_WINDOW_AUTOSIZE);
 
@@ -138,12 +138,12 @@ int thread_func(const char *path, int gpu_mode, RocalImageColor color_format, in
             break;
         // copy output to host as image
         rocalCopyToOutput(handle, mat_input.data, h * w * p);
-        unsigned img_name_size = rocalGetImageNameLen(handle, image_name_length);
-        char img_name[img_name_size];
-        rocalGetImageName(handle, img_name);
+        unsigned img_name_size = rocalGetImageNameLen(handle, image_name_length.data());
+        std::vector<char> img_name(img_name_size);
+        rocalGetImageName(handle, img_name.data());
 #if PRINT_NAMES_AND_LABELS
         RocalTensorList labels = rocalGetImageLabels(handle);
-        std::string imageNamesStr(img_name);
+        std::string imageNamesStr(img_name.data());
         int pos = 0;
         int *labels_buffer = reinterpret_cast<int *>(labels->at(0)->buffer());
         for (int i = 0; i < batch_size; i++) {
@@ -231,7 +231,7 @@ int main(int argc, const char **argv) {
     std::cout << "Number of GPUs: " << num_gpus << std::endl;
 
     // launch threads process shards
-    std::thread loader_threads[num_shards];
+    std::vector<std::thread> loader_threads(num_shards);
     auto gpu_id = num_gpus ? 0 : -1;
     int th_id;
     for (th_id = 0; th_id < num_shards; th_id++) {

--- a/tests/cpp_api/performance_tests_with_depth/performance_tests_with_depth.cpp
+++ b/tests/cpp_api/performance_tests_with_depth/performance_tests_with_depth.cpp
@@ -274,7 +274,7 @@ int test(int test_case, const char* path, int rgb, int gpu, int width, int heigh
             for (int j = 0; j < batch_size; j++) {
                 tensor0 = input_image;
                 for (int k = 0; k < graph_depth; k++) {
-                    tensor0 = rocalBlurFixed(handle, tensor0, 17.25, true);
+                    tensor0 = rocalBlurFixed(handle, tensor0, 17, true);
                 }
             }
         } break;
@@ -316,7 +316,7 @@ int test(int test_case, const char* path, int rgb, int gpu, int width, int heigh
             for (int j = 0; j < batch_size; j++) {
                 tensor0 = input_image;
                 for (int k = 0; k < graph_depth; k++) {
-                    tensor0 = rocalWarpAffineFixed(handle, tensor0, true, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5);
+                    tensor0 = rocalWarpAffineFixed(handle, tensor0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, true);
                 }
             }
         } break;
@@ -379,7 +379,7 @@ int test(int test_case, const char* path, int rgb, int gpu, int width, int heigh
             for (int j = 0; j < batch_size; j++) {
                 tensor0 = input_image;
                 for (int k = 0; k < graph_depth; k++) {
-                    tensor0 = rocalSnPNoiseFixed(handle, tensor0, true, 0.2, 0.2, 0.2, 0.5, 0);
+                    tensor0 = rocalSnPNoiseFixed(handle, tensor0, 0.2, 0.2, 0.2, 0.5, true, 0);
                 }
             }
         } break;
@@ -451,7 +451,7 @@ int test(int test_case, const char* path, int rgb, int gpu, int width, int heigh
             for (int j = 0; j < batch_size; j++) {
                 tensor0 = input_image;
                 for (int k = 0; k < graph_depth; k++) {
-                    tensor0 = rocalFogFixed(handle, tensor0, true, 2.5);
+                    tensor0 = rocalFogFixed(handle, tensor0, 2.5, true);
                 }
             }
         } break;

--- a/tests/cpp_api/unit_tests/unit_tests.cpp
+++ b/tests/cpp_api/unit_tests/unit_tests.cpp
@@ -153,7 +153,7 @@ int main(int argc, const char **argv) {
 
 int test(int test_case, int reader_type, const char *path, const char *outName, int rgb, int gpu, int width, int height, int num_of_classes, int display_all, int resize_interpolation_type, int resize_scaling_mode) {
     size_t num_threads = 1;
-    unsigned int input_batch_size = 2;
+    const unsigned int input_batch_size = 2;
     int decode_max_width = width;
     int decode_max_height = height;
     int pipeline_type = -1;
@@ -639,13 +639,13 @@ int test(int test_case, int reader_type, const char *path, const char *outName, 
                 RocalTensorList labels = rocalGetImageLabels(handle);
                 int *label_id = reinterpret_cast<int *>(labels->at(0)->buffer());  // The labels are present contiguously in memory
                 int img_size = rocalGetImageNameLen(handle, image_name_length);
-                char img_name[img_size];
-                int label_one_hot_encoded[input_batch_size * num_of_classes];
-                rocalGetImageName(handle, img_name);
+                std::vector<char> img_name(img_size);
+                std::vector<int> label_one_hot_encoded(input_batch_size * num_of_classes);
+                rocalGetImageName(handle, img_name.data());
                 if (num_of_classes != 0) {
-                    rocalGetOneHotImageLabels(handle, label_one_hot_encoded, num_of_classes, RocalOutputMemType::ROCAL_MEMCPY_HOST);
+                    rocalGetOneHotImageLabels(handle, label_one_hot_encoded.data(), num_of_classes, RocalOutputMemType::ROCAL_MEMCPY_HOST);
                 }
-                std::cerr << "\nImage name:" << img_name << "\n";
+                std::cerr << "\nImage name:" << img_name.data() << "\n";
                 for (unsigned int i = 0; i < input_batch_size; i++) {
                     std::cerr << "Label id: " << label_id[i] << std::endl;
                     if(num_of_classes != 0)
@@ -667,9 +667,9 @@ int test(int test_case, int reader_type, const char *path, const char *outName, 
             } break;
             case 2: {   // detection pipeline
                 int img_size = rocalGetImageNameLen(handle, image_name_length);
-                char img_name[img_size];
-                rocalGetImageName(handle, img_name);
-                std::cerr << "\nImage name:" << img_name;
+                std::vector<char> img_name(img_size);
+                rocalGetImageName(handle, img_name.data());
+                std::cerr << "\nImage name:" << img_name.data();
                 RocalTensorList bbox_labels = rocalGetBoundingBoxLabel(handle);
                 RocalTensorList bbox_coords = rocalGetBoundingBoxCords(handle);
                 for (unsigned i = 0; i < bbox_labels->size(); i++) {

--- a/tests/cpp_api/video_tests/video_tests.cpp
+++ b/tests/cpp_api/video_tests/video_tests.cpp
@@ -282,13 +282,13 @@ int main(int argc, const char **argv) {
             }
         }
         if (enable_metadata) {
-            int image_name_length[input_batch_size];
+            std::vector<int> image_name_length(input_batch_size);
             RocalTensorList labels = rocalGetImageLabels(handle);
-            int img_size = rocalGetImageNameLen(handle, image_name_length);
-            char img_name[img_size];
-            rocalGetImageName(handle, img_name);
+            int img_size = rocalGetImageNameLen(handle, image_name_length.data());
+            std::vector<char> img_name(img_size);
+            rocalGetImageName(handle, img_name.data());
 
-            std::cout << "\nImage names: " << img_name << "\n";
+            std::cout << "\nImage names: " << img_name.data() << "\n";
             std::cout << "Label id: ";
             int *label_id = reinterpret_cast<int *>(labels->at(0)->buffer());
             for (unsigned i = 0; i < input_batch_size; i++) {
@@ -297,11 +297,11 @@ int main(int argc, const char **argv) {
             std::cout << std::endl;
         }
         if (enable_framenumbers || enable_timestamps) {
-            unsigned int start_frame_num[input_batch_size];
-            float frame_timestamps[input_batch_size * sequence_length];
-            rocalGetSequenceStartFrameNumber(handle, start_frame_num);
+            std::vector<unsigned int> start_frame_num(input_batch_size);
+            std::vector<float> frame_timestamps(input_batch_size * sequence_length);
+            rocalGetSequenceStartFrameNumber(handle, start_frame_num.data());
             if (enable_timestamps) {
-                rocalGetSequenceFrameTimestamps(handle, frame_timestamps);
+                rocalGetSequenceFrameTimestamps(handle, frame_timestamps.data());
             }
             for (unsigned i = 0; i < input_batch_size; i++) {
                 if (enable_framenumbers)


### PR DESCRIPTION
- Removed unused variables
- Add missing override keyword and missing virtual destructors
- Fix warnings wrt return-type-c-linkage for the Metadata API and NonSilentRegionDetection API
- Introduce a new class to store the list of rocALTensorList for the metadata
- Introduce new struct to store the anchor and shape tensors for NonSilentRegionDetetction API